### PR TITLE
Postman v6.7.3 with URLs corrected to specific version download instead of latest

### DIFF
--- a/postman.nuspec
+++ b/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>6.7.2</version>
+    <version>6.7.3</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = "postman"
 $fileType = "exe"
 $silentArgs = "-s"
-$url = "https://dl.pstmn.io/download/latest/win32"
-$url64 = "https://dl.pstmn.io/download/latest/win64"
+$url = "https://dl.pstmn.io/download/version/6.7.3/windows3"
+$url64 = "https://dl.pstmn.io/download/version/6.7.3/windows64"
 
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url $url64


### PR DESCRIPTION
- Set URLs to targeted version for download instead of latest. This will ensure Nuget package version aligns with the version that is downloaded.