### PR TITLE
Catch up to v7.16.1

### DIFF
--- a/postman.nuspec
+++ b/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>7.16.0</version>
+    <version>7.16.1</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/postman.nuspec
+++ b/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>7.15.0</version>
+    <version>7.16.0</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/postman.nuspec
+++ b/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>7.14.0</version>
+    <version>7.15.0</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://dl.pstmn.io/download/version/7.15.0/windows32'
-$url64      = 'https://dl.pstmn.io/download/version/7.15.0/windows64'
+$url        = 'https://dl.pstmn.io/download/version/7.16.0/windows32'
+$url64      = 'https://dl.pstmn.io/download/version/7.16.0/windows64'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -9,9 +9,9 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
   silentArgs    = "-s"
-  checksum      = 'F11177702A4DF0DC1E0B877CB0E071A12CE65F710304E40570737016D9287F41'
+  checksum      = '09FE2B642CFA8C8EAA422ED8033222CD5C113B24F4CE213A9A587F8C5DC7AA56'
   checksumType  = 'sha256'
-  checksum64    = 'B510B5A28E0BF45A8019536C676490EA114E8FFCB294C96B7C0EC5A2CE43AD2C'
+  checksum64    = '4B5A7877E82760D58109913D09B1EECD9D2AD33BF40A3455A974D86145E4B711'
   checksumType64= 'sha256'
 }
 

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://dl.pstmn.io/download/version/7.14.0/windows32'
-$url64      = 'https://dl.pstmn.io/download/version/7.14.0/windows64'
+$url        = 'https://dl.pstmn.io/download/version/7.15.0/windows32'
+$url64      = 'https://dl.pstmn.io/download/version/7.15.0/windows64'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -9,9 +9,9 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
   silentArgs    = "-s"
-  checksum      = 'BD1FF7C3DF82C3490AFE1027348EA9DEC91F3EDB2C1C23BB4BCB17143CD86A47'
+  checksum      = 'F11177702A4DF0DC1E0B877CB0E071A12CE65F710304E40570737016D9287F41'
   checksumType  = 'sha256'
-  checksum64    = '2F131A7DAAB79985C956B80F30DC2C05A119E614235344EB60CCD09C534C9323'
+  checksum64    = 'B510B5A28E0BF45A8019536C676490EA114E8FFCB294C96B7C0EC5A2CE43AD2C'
   checksumType64= 'sha256'
 }
 

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://dl.pstmn.io/download/version/7.16.0/windows32'
-$url64      = 'https://dl.pstmn.io/download/version/7.16.0/windows64'
+$url        = 'https://dl.pstmn.io/download/version/7.16.1/windows32'
+$url64      = 'https://dl.pstmn.io/download/version/7.16.1/windows64'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -9,9 +9,9 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
   silentArgs    = "-s"
-  checksum      = '09FE2B642CFA8C8EAA422ED8033222CD5C113B24F4CE213A9A587F8C5DC7AA56'
+  checksum      = 'D1C12F6EF20486CACA563AA9F9366F82A7D619D7A612119D3DFEDF87324BAD44'
   checksumType  = 'sha256'
-  checksum64    = '4B5A7877E82760D58109913D09B1EECD9D2AD33BF40A3455A974D86145E4B711'
+  checksum64    = '0029065FB039FA52AE0D327E8012C14F71B8531A38015AAA63F0CB8299DB9071'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Postman's version is up to v7.16.1 now - current source is at v7.14.0 from my last PR.

Separate commits have been created for packaging v7.15.0, v7.16.0, and v7.16.1, if desired.