### PR TITLE
Add packageSourceUrl to NuSpec

### DIFF
--- a/postman.nuspec
+++ b/postman.nuspec
@@ -10,6 +10,7 @@
     <summary>Postman for Windows</summary>
     <description>Postman helps you be more efficient while working with APIs. Using Postman, you can construct complex HTTP requests quickly, organize them in collections and share them with your co-workers.</description>
     <projectUrl>https://www.getpostman.com/</projectUrl>
+    <packageSourceUrl>https://github.com/kendaleiv/chocolatey-postman</packageSourceUrl>
     <iconUrl>https://raw.githubusercontent.com/kendaleiv/chocolatey-postman/master/postman-logo.png</iconUrl>
     <tags>postman</tags>
     <copyright>Postdot Technologies, Inc.</copyright>


### PR DESCRIPTION
The community package page links to this repository as a Possible Package Source. The tooltip on the link elaborates as such: `This is a possible package source. NuSpec did not contain <packageSourceUrl />, but it did contain an icon url from a repository location.`

This change simply adds the missing tag, intended to provide users with more confidence that this is indeed the official package source.