### PR TITLE
Automate package updates via AU

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,37 @@
+Import-Module au
+
+function global:au_BeforeUpdate ($Package)  {
+	
+}
+
+function global:au_AfterUpdate ($Package)  {
+
+}
+
+function global:au_SearchReplace {
+	@{
+		'postman.nuspec' = @{
+			"<version>[^<]*</version>" = "<version>$($Latest.Version)</version>"
+		}
+		'tools\chocolateyInstall.ps1' = @{
+			"(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.Url32)'"
+			"(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+			"(^[$]url64\s*=\s*)('.*')" = "`$1'$($Latest.Url64)'"
+			"(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+		}
+	}
+}
+
+function global:au_GetLatest {
+	$jsonReleaseNotesUri = 'https://dl.pstmn.io/api/version/notes?channel=stable'
+	$jsonResponse = Invoke-RestMethod -Method Get -Uri $jsonReleaseNotesUri
+	
+	$version = [Version] $jsonResponse.notes[0].version
+
+	$url32 = "https://dl.pstmn.io/download/version/$($version.Major).$($version.Minor).$($version.Build)/windows32"
+	$url64 = "https://dl.pstmn.io/download/version/$($version.Major).$($version.Minor).$($version.Build)/windows64"
+
+	return @{ Url32 = $url32; Url64 = $url64; Version = $version }
+}
+
+Update-Package -NoReadme


### PR DESCRIPTION
This changeset implements an update script that utilizes the [Chocolatey Automatic Package Updater Module](https://community.chocolatey.org/packages/au), to assist with keeping this package up-to-date.

To test:
1. `choco install au`
2. Wait for another Postman update, or revert local repository to a previous commit and add `-NoCheckChocoVersion` to the `Update-Package` call.
3. Rename local repository's parent directory to package's id (`postman`), or create a junction point that points to your local repository.
   **NOTE:** This quirk is due to AU expecting adoption of a monorepo of packages ([example template](https://github.com/majkinetor/au-packages-template)).
4. `cd` to the renamed directory/junction point, and execute `.\update.ps1`.

`postman.nuspec` and `chocolateyInstall.ps1` should be updated as needed, and a new package that consumes the updated files is automatically packed.