### PR TITLE
Remove 32-bit support and update to v9.15.2

### DIFF
--- a/postman/postman.nuspec
+++ b/postman/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>9.4.1</version>
+    <version>9.15.2</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/postman/tools/chocolateyInstall.ps1
+++ b/postman/tools/chocolateyInstall.ps1
@@ -1,16 +1,12 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://dl.pstmn.io/download/version/9.4.1/windows32'
 $url64      = 'https://dl.pstmn.io/download/version/9.4.1/windows64'
 
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'exe'
-  url           = $url
-  url64bit      = $url64
   silentArgs    = "-s"
-  checksum      = '328d481ced8747a39214f0f687d1e07146469f1c22a3fef584bdf1ba0bd31db3'
-  checksumType  = 'sha256'
+  url64bit      = $url64
   checksum64    = '2adcce5b4f15e3347b56c899732b94f10310af30a08d33fed96fd0a6df992156'
   checksumType64= 'sha256'
 }

--- a/postman/tools/chocolateyInstall.ps1
+++ b/postman/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url64      = 'https://dl.pstmn.io/download/version/9.4.1/windows64'
+$url64      = 'https://dl.pstmn.io/download/version/9.15.2/win64'
 
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'exe'
   silentArgs    = "-s"
   url64bit      = $url64
-  checksum64    = '2adcce5b4f15e3347b56c899732b94f10310af30a08d33fed96fd0a6df992156'
+  checksum64    = '452d68a14e65a1bc2c814f472945379e87bf62d650f7e9a1eec96f8343349c94'
   checksumType64= 'sha256'
 }
 

--- a/postman/update.ps1
+++ b/postman/update.ps1
@@ -14,8 +14,6 @@ function global:au_SearchReplace {
 			"<version>[^<]*</version>" = "<version>$($Latest.Version)</version>"
 		}
 		'tools\chocolateyInstall.ps1' = @{
-			"(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.Url32)'"
-			"(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
 			"(^[$]url64\s*=\s*)('.*')" = "`$1'$($Latest.Url64)'"
 			"(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
 		}
@@ -28,10 +26,9 @@ function global:au_GetLatest {
 	
 	$version = [Version] $jsonResponse.notes[0].version
 
-	$url32 = "https://dl.pstmn.io/download/version/$($version.Major).$($version.Minor).$($version.Build)/windows32"
-	$url64 = "https://dl.pstmn.io/download/version/$($version.Major).$($version.Minor).$($version.Build)/windows64"
+	$url64 = "https://dl.pstmn.io/download/version/$($version.Major).$($version.Minor).$($version.Build)/win64"
 
-	return @{ Url32 = $url32; Url64 = $url64; Version = $version }
+	return @{ Url64 = $url64; Version = $version }
 }
 
-Update-Package -NoReadme
+Update-Package -NoReadme -ChecksumFor 64


### PR DESCRIPTION
Postman doesn't support 32-bit versions after v9.4 ([link](https://learning.postman.com/docs/getting-started/installation-and-updates/#installing-postman-on-windows)).
The package is also updated to v9.15.2.
