### PR TITLE
Revert "10.0.1"

### DIFF
--- a/postman/postman.nuspec
+++ b/postman/postman.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>postman</id>
     <title>Postman for Windows</title>
-    <version>10.0.1</version>
+    <version>9.29.0</version>
     <authors>Postdot Technologies, Inc.</authors>
     <owners>kendaleiv</owners>
     <summary>Postman for Windows</summary>

--- a/postman/tools/chocolateyInstall.ps1
+++ b/postman/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 ﻿$packageName= 'postman'
 $toolsDir   = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-$url64      = 'https://dl.pstmn.io/download/version/10.0.1/win64'
+$url64      = 'https://dl.pstmn.io/download/version/9.29.0/win64'
 
 $packageArgs = @{
   packageName   = $packageName
   fileType      = 'exe'
   silentArgs    = "-s"
   url64bit      = $url64
-  checksum64    = '569397bc1568018703c41541ca3dcda173be92df7e9fdb05477b3e43e6efbae3'
+  checksum64    = '11c56acc74c7998afa60bfc2c483cf55c56f1488546817cb13e7985fc1cde47b'
   checksumType64= 'sha256'
 }
 


### PR DESCRIPTION
Hi @kendaleiv, 

Thanks for maintaining this package for our users.

Postman v10 is in early access and we've been slowly rolling this out to our users. As of today, we are not ready to rollout to all users using the Chocolatey package. Users who aren't part of our controlled rollout will be asked to downgrade to v9 when they open the 10.0.1 package. It'll save our users and community a great deal of confusion and frustration if you could revert or unpublish the 10.0.1 version for now till we are ready to rollout v10 to our wider user base. 

Looking forward to working together in bringing v10 to our users in a controlled manner. 